### PR TITLE
fix: build time error caused by the same identifier : `UserList`

### DIFF
--- a/projects/remesh-example/src/others/pagination.tsx
+++ b/projects/remesh-example/src/others/pagination.tsx
@@ -112,12 +112,12 @@ export default () => {
   return (
     <div>
       <h2>Pagination</h2>
-      {isEmptyUserList ? 'loading...' : <UserList />}
+      {isEmptyUserList ? 'loading...' : <UserListView />}
     </div>
   )
 }
 
-const UserList = () => {
+const UserListView = () => {
   const paginationDomain = useRemeshDomain(PaginationDomain())
 
   const isLoading = useRemeshQuery(paginationDomain.query.isLoading())


### PR DESCRIPTION
Identifier `UserList` has already been declared by type definition `UserList`