### PR TITLE
fix: remove `React.FC`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
       remesh-react: ^1.0.0
       remesh-redux-devtools: ^1.0.0
       rxjs: ^7.0.0
-      tailwindcss: 3.0.5
+      tailwindcss: ^3.0.5
       typescript: ^4.2.4
     dependencies:
       classnames: 2.3.1

--- a/projects/nextjs-demo/components/container.tsx
+++ b/projects/nextjs-demo/components/container.tsx
@@ -1,10 +1,10 @@
-import React, { ReactNode, FunctionComponent } from 'react'
+import React, { ReactNode } from 'react'
 
 type Props = {
   children?: ReactNode
 }
 
-const Container: React.FC<Props> = ({ children }) => {
+const Container = ({ children }: Props) => {
   return <div className="container mx-auto px-5">{children}</div>
 }
 

--- a/projects/nextjs-demo/components/header.tsx
+++ b/projects/nextjs-demo/components/header.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Link from 'next/link'
 
-const Header: React.FC = () => {
+const Header = () => {
   return (
     <h2 className="text-2xl md:text-4xl font-bold tracking-tight md:tracking-tighter leading-tight mb-20 mt-8">
       <Link href="/">

--- a/projects/nextjs-demo/components/intro.tsx
+++ b/projects/nextjs-demo/components/intro.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { CMS_NAME } from '../lib/constants'
 
-const Intro: React.FC = () => {
+const Intro = () => {
   return (
     <section className="flex-col md:flex-row flex items-center md:justify-between mt-16 mb-16 md:mb-12">
       <h1 className="text-5xl md:text-8xl font-bold tracking-tighter leading-tight md:pr-8">

--- a/projects/nextjs-demo/pages/preload.tsx
+++ b/projects/nextjs-demo/pages/preload.tsx
@@ -63,7 +63,12 @@ const Counter = () => {
   )
 }
 
-const Button: React.FC<{ children: React.ReactNode; onClick: () => unknown }> = (props) => {
+export type ButtonProps = {
+  children: React.ReactNode,
+  onClick: () => unknown
+}
+
+const Button = (props: ButtonProps) => {
   return (
     <button
       className="mx-3 bg-black hover:bg-white hover:text-black border border-black text-white font-bold py-3 px-12 lg:px-8 duration-200 transition-colors mb-6 lg:mb-0"


### PR DESCRIPTION
`React.FC` is discouraged, it was removed from the Create React App TypeScript template, [related PR](https://github.com/facebook/create-react-app/pull/8177)