### PR TITLE
ci: remove node 15.x , which reached its EOL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
+        node-version: [14.x, 16.x, 17.x, 18.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
remove support for `Node.js` 15.x , which reached its [EOL](https://nodejs.org/en/about/releases/)